### PR TITLE
Fix error table logging

### DIFF
--- a/src/main/kotlin/io/github/ddsimoes/muddt/RawDump.kt
+++ b/src/main/kotlin/io/github/ddsimoes/muddt/RawDump.kt
@@ -44,9 +44,9 @@ class RawDump(val options: RawDumpOptions) : Runnable {
 
         if (errorTables.isNotEmpty()) {
             val errorFile = options.dir / "error-${System.currentTimeMillis()}.txt"
-            errorFile.printWriter().use {
-                errorTables.forEach {
-                    println(it)
+            errorFile.printWriter().use { writer ->
+                errorTables.forEach { table ->
+                    writer.println(table)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- write error table names to error file

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c0b06850c83319d74dd303199da5b