### PR TITLE
Add Testcontainers based test suite

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,9 @@ dependencies {
     implementation("com.oracle.ojdbc:ojdbc8:19.3.0.0")
     implementation("com.esotericsoftware:kryo:5.1.1")
     testImplementation(kotlin("test"))
+    testImplementation("org.testcontainers:junit-jupiter:1.19.7")
+    testImplementation("org.testcontainers:oracle-xe:1.19.7")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.2.1")
 }
 
 tasks.test {

--- a/src/test/kotlin/io/github/ddsimoes/muddt/RawDumpIntegrationTest.kt
+++ b/src/test/kotlin/io/github/ddsimoes/muddt/RawDumpIntegrationTest.kt
@@ -1,0 +1,71 @@
+import io.github.ddsimoes.muddt.ClearType
+import io.github.ddsimoes.muddt.RawDump
+import io.github.ddsimoes.muddt.RawDumpLoader
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestInstance.Lifecycle
+import org.junit.jupiter.api.extension.ExtendWith
+import org.testcontainers.containers.OracleContainer
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import java.io.File
+import java.sql.DriverManager
+
+@Testcontainers
+@TestInstance(Lifecycle.PER_CLASS)
+class RawDumpIntegrationTest {
+    companion object {
+        @Container
+        val oracle: OracleContainer = OracleContainer("gvenzl/oracle-xe:21-slim")
+            .withReuse(false)
+    }
+
+    private fun props() = mapOf(
+        "db.user" to oracle.username,
+        "db.password" to oracle.password
+    )
+
+    @Test
+    fun `dump and load simple table`() {
+        val conn = DriverManager.getConnection(oracle.jdbcUrl, oracle.username, oracle.password)
+        conn.createStatement().use { st ->
+            st.execute("CREATE TABLE TEST_TABLE(id NUMBER PRIMARY KEY, name VARCHAR2(50))")
+            st.execute("INSERT INTO TEST_TABLE(id, name) VALUES (1, 'one')")
+            st.execute("INSERT INTO TEST_TABLE(id, name) VALUES (2, 'two')")
+            conn.commit()
+        }
+
+        val dumpDir = createTempDir(prefix = "dump")
+        val tablesFile = File(dumpDir, "tables.txt")
+        tablesFile.writeText("TEST_TABLE\n")
+
+        val dumpOptions = RawDump.RawDumpOptions(props(), "kryo", tablesFile, dumpDir, 1000, 1000, -1, oracle.jdbcUrl)
+        RawDump(dumpOptions).run()
+
+        conn.createStatement().execute("TRUNCATE TABLE TEST_TABLE")
+        conn.commit()
+
+        val loadOptions = RawDumpLoader.Options(
+            properties = props(),
+            dir = dumpDir,
+            batchSize = 100,
+            printCount = 1000,
+            limit = -1,
+            commitCount = 0,
+            skipNonEmpty = false,
+            clear = ClearType.NO,
+            offset = -1,
+            memInfo = false,
+            url = oracle.jdbcUrl
+        )
+        RawDumpLoader(loadOptions).run()
+
+        conn.createStatement().use { st ->
+            val rs = st.executeQuery("SELECT COUNT(*) FROM TEST_TABLE")
+            rs.next()
+            val count = rs.getInt(1)
+            assertEquals(2, count)
+        }
+    }
+}

--- a/src/test/kotlin/io/github/ddsimoes/muddt/SerializerTest.kt
+++ b/src/test/kotlin/io/github/ddsimoes/muddt/SerializerTest.kt
@@ -1,0 +1,21 @@
+import com.esotericsoftware.kryo.io.Input
+import com.esotericsoftware.kryo.io.Output
+import io.github.ddsimoes.muddt.BigDecimalSerializer
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.math.BigDecimal
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SerializerTest {
+    @Test
+    fun `bigdecimal roundtrip`() {
+        val outputStream = ByteArrayOutputStream()
+        val output = Output(outputStream)
+        BigDecimalSerializer.write(output, BigDecimal("123.45"))
+        output.close()
+        val input = Input(ByteArrayInputStream(outputStream.toByteArray()))
+        val result = BigDecimalSerializer.read(input)
+        assertEquals(BigDecimal("123.45"), result)
+    }
+}

--- a/src/test/kotlin/io/github/ddsimoes/muddt/StructTextConverterTest.kt
+++ b/src/test/kotlin/io/github/ddsimoes/muddt/StructTextConverterTest.kt
@@ -1,0 +1,17 @@
+import io.github.ddsimoes.muddt.StructTextConverter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.sql.Struct
+
+class StructTextConverterTest {
+    @Test
+    fun `convert simple struct`() {
+        val struct = mock<Struct>()
+        whenever(struct.sqlTypeName).thenReturn("SIMPLE_TYPE")
+        whenever(struct.attributes).thenReturn(arrayOf("a", 1))
+        val result = StructTextConverter.invoke(struct)
+        assertEquals("!SIMPLE_TYPE:a|1", result)
+    }
+}


### PR DESCRIPTION
## Summary
- setup testcontainers dependencies
- add integration test that starts Oracle XE container
- add unit tests for StructTextConverter and BigDecimalSerializer

## Testing
- `./gradlew test --no-daemon` *(fails: `RawDumpIntegrationTest` could not start Docker container)*

------
https://chatgpt.com/codex/tasks/task_e_684c14898b208331b7323e4afd16c53f