### PR TITLE
Add Testcontainers based Oracle tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,10 @@ dependencies {
     implementation("com.github.ajalt.clikt:clikt:4.2.0")
     implementation("com.oracle.ojdbc:ojdbc8:19.3.0.0")
     implementation("com.esotericsoftware:kryo:5.1.1")
-    testImplementation(kotlin("test"))
+    testImplementation(kotlin("test-junit5"))
+    testImplementation("org.testcontainers:junit-jupiter:1.19.7")
+    testImplementation("org.testcontainers:testcontainers:1.19.7")
+    testImplementation("org.testcontainers:oracle-xe:1.19.7")
 }
 
 tasks.test {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     testImplementation(kotlin("test-junit5"))
     testImplementation("org.testcontainers:junit-jupiter:1.19.7")
     testImplementation("org.testcontainers:testcontainers:1.19.7")
-    testImplementation("org.testcontainers:oracle-xe:1.19.7")
+    testImplementation("org.testcontainers:oracle-free:1.20.0")
 }
 
 tasks.test {

--- a/src/main/kotlin/io/github/ddsimoes/muddt/KryoWriter.kt
+++ b/src/main/kotlin/io/github/ddsimoes/muddt/KryoWriter.kt
@@ -17,7 +17,18 @@ private const val RECORD: Byte = (0xFF).toByte()
 private const val EOF: Byte = 3
 
 
-class KryoWriter(outputStream: OutputStream, private val rs: ResultSet, private val limit: Int, private val printCount: Int): Closeable {
+class KryoWriter(
+    outputStream: OutputStream,
+    private val tableName: String,
+    columns: List<String>,
+    private val rs: ResultSet,
+    private val limit: Int,
+    private val printCount: Int
+): Closeable {
+
+    init {
+        check(tableName.isNotBlank()) { "table name can't be blank" }
+    }
 
     private val output = Output(outputStream)
 
@@ -62,7 +73,7 @@ class KryoWriter(outputStream: OutputStream, private val rs: ResultSet, private 
 
     private fun writeHeader() {
         output.writeByte(HEADER)
-        output.writeString(rs.metaData.getTableName(1))
+        output.writeString(tableName)
         output.writeVarInt(columns.size, true)
         columns.forEachIndexed { index, column ->
             print(index + 1)

--- a/src/test/kotlin/io/github/ddsimoes/muddt/RawDumpLoaderTest.kt
+++ b/src/test/kotlin/io/github/ddsimoes/muddt/RawDumpLoaderTest.kt
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
-import org.testcontainers.containers.OracleContainer
+import org.testcontainers.oracle.OracleContainer
 import java.nio.file.Files
 import java.sql.DriverManager
 
@@ -13,7 +13,7 @@ import java.sql.DriverManager
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class RawDumpLoaderTest {
     @Container
-    private val oracle = OracleContainer("gvenzl/oracle-free:23-slim")
+    private val oracle = OracleContainer("gvenzl/oracle-free:23.4-slim-faststart")
 
     private val props: Map<String, String> by lazy {
         mapOf(
@@ -25,6 +25,7 @@ class RawDumpLoaderTest {
     @BeforeEach
     fun setUp() {
         val conn = DriverManager.getConnection(oracle.jdbcUrl, oracle.username, oracle.password)
+        conn.autoCommit = false
         conn.createStatement().use { stmt ->
             try {
                 stmt.executeUpdate("DROP TABLE test_table")
@@ -56,7 +57,7 @@ class RawDumpLoaderTest {
 
         DriverManager.getConnection(oracle.jdbcUrl, oracle.username, oracle.password).use { conn ->
             conn.createStatement().executeUpdate("TRUNCATE TABLE test_table")
-            conn.commit()
+            //conn.commit()
         }
 
         val loadOptions = RawDumpLoader.Options(

--- a/src/test/kotlin/io/github/ddsimoes/muddt/RawDumpLoaderTest.kt
+++ b/src/test/kotlin/io/github/ddsimoes/muddt/RawDumpLoaderTest.kt
@@ -1,0 +1,86 @@
+import io.github.ddsimoes.muddt.*
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.containers.OracleContainer
+import java.nio.file.Files
+import java.sql.DriverManager
+
+@Testcontainers
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class RawDumpLoaderTest {
+    @Container
+    private val oracle = OracleContainer("gvenzl/oracle-free:23-slim")
+
+    private val props: Map<String, String> by lazy {
+        mapOf(
+            "db.user" to oracle.username,
+            "db.password" to oracle.password
+        )
+    }
+
+    @BeforeEach
+    fun setUp() {
+        val conn = DriverManager.getConnection(oracle.jdbcUrl, oracle.username, oracle.password)
+        conn.createStatement().use { stmt ->
+            try {
+                stmt.executeUpdate("DROP TABLE test_table")
+            } catch (_: Exception) {
+            }
+            stmt.executeUpdate("CREATE TABLE test_table (id NUMBER PRIMARY KEY, name VARCHAR2(50))")
+            stmt.executeUpdate("INSERT INTO test_table (id, name) VALUES (1, 'foo')")
+            conn.commit()
+        }
+        conn.close()
+    }
+
+    @Test
+    fun `dump and load table`() {
+        val tablesFile = Files.createTempFile("tables", ".txt").toFile().apply { writeText("test_table\n") }
+        val dumpDir = Files.createTempDirectory("dump").toFile()
+
+        val dumpOptions = RawDump.RawDumpOptions(
+            props,
+            "kryo",
+            tablesFile,
+            dumpDir,
+            fetchSize = 1000,
+            printCount = 1000,
+            limit = -1,
+            url = oracle.jdbcUrl
+        )
+        RawDump(dumpOptions).run()
+
+        DriverManager.getConnection(oracle.jdbcUrl, oracle.username, oracle.password).use { conn ->
+            conn.createStatement().executeUpdate("TRUNCATE TABLE test_table")
+            conn.commit()
+        }
+
+        val loadOptions = RawDumpLoader.Options(
+            props,
+            dumpDir,
+            batchSize = 1000,
+            printCount = 1000,
+            limit = -1,
+            commitCount = 0,
+            skipNonEmpty = false,
+            clear = ClearType.NO,
+            offset = -1,
+            memInfo = false,
+            url = oracle.jdbcUrl
+        )
+        RawDumpLoader(loadOptions).run()
+
+        DriverManager.getConnection(oracle.jdbcUrl, oracle.username, oracle.password).use { conn ->
+            val count = conn.createStatement().executeQuery("SELECT count(*) FROM test_table").use { rs ->
+                rs.next()
+                rs.getInt(1)
+            }
+            Assertions.assertEquals(1, count)
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- add Testcontainers dependencies
- implement RawDumpLoaderTest using Oracle container

## Testing
- `./gradlew test` *(fails: IllegalStateException at RawDumpLoaderTest.kt:16)*

------
https://chatgpt.com/codex/tasks/task_e_684c9b1087388331a2d39044aa72c9a1